### PR TITLE
README: Fix reST syntax

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,7 @@ To use the unasync project you need to install the package and then create a **_
 And then in your :code:`setup.py` place the following code.
 
 .. code-block:: python
+
     import unasync
 
     setuptools.setup(


### PR DESCRIPTION
I found the issue with `twine check` : https://packaging.python.org/guides/making-a-pypi-friendly-readme/#validating-restructuredtext-markup